### PR TITLE
Generalize Kernel and Point Type

### DIFF
--- a/include/PolygonSimplification.hpp
+++ b/include/PolygonSimplification.hpp
@@ -40,16 +40,17 @@ namespace com {
 			};
 			
 			template<class Kernel>
-			struct cgal_infer_point_kernel< Point_2<Kernel> > {
+			struct cgal_infer_point_kernel<CGAL::Point_2<Kernel> > {
 				using type = Kernel;
 			};
 			
 			template<class Point>
 			using cgal_infer_point_kernel_t = typename cgal_infer_point_kernel<Point>::type;
 		}
-		template<typename Point = typename CGAL::Exact_predicates_exact_constructions_kernel::Point_2>
+
+		template<typename Point = typename CGAL::Point_2<CGAL::Exact_predicates_exact_constructions_kernel>>
 		class PolySimp {
-			using CGALKernel = PolySimpCustomization::cgal_infer_point_kernel_t<Point>
+			using CGALKernel = PolySimpCustomization::cgal_infer_point_kernel_t<Point>;
 			using CGALPoint = Point;
 			using CGALPolygon = CGAL::Polygon_2<CGALKernel, std::vector<Point>>;
 			

--- a/include/PolygonSimplification.hpp
+++ b/include/PolygonSimplification.hpp
@@ -33,9 +33,23 @@
 
 namespace com {
 	namespace geopipe {
-		template<typename Kernel = CGAL::Exact_predicates_exact_constructions_kernel, typename Point = typename Kernel::Point_2>
+		namespace PolySimpCustomization { 
+			template<class Point>
+			struct cgal_infer_point_kernel {
+				using type = typename Point::Kernel;
+			};
+			
+			template<class Kernel>
+			struct cgal_infer_point_kernel< Point_2<Kernel> > {
+				using type = Kernel;
+			};
+			
+			template<class Point>
+			using cgal_infer_point_kernel_t = typename cgal_infer_point_kernel<Point>::type;
+		}
+		template<typename Point = typename CGAL::Exact_predicates_exact_constructions_kernel::Point_2>
 		class PolySimp {
-			using CGALKernel = Kernel;
+			using CGALKernel = PolySimpCustomization::cgal_infer_point_kernel_t<Point>
 			using CGALPoint = Point;
 			using CGALPolygon = CGAL::Polygon_2<CGALKernel, std::vector<Point>>;
 			

--- a/include/PolygonSimplification.hpp
+++ b/include/PolygonSimplification.hpp
@@ -33,26 +33,10 @@
 
 namespace com {
 	namespace geopipe {
-		namespace PolySimpCustomization { 
-			template<class Point>
-			struct cgal_infer_point_kernel {
-				using type = typename Point::Kernel;
-			};
-			
-			template<class Kernel>
-			struct cgal_infer_point_kernel<CGAL::Point_2<Kernel> > {
-				using type = Kernel;
-			};
-			
-			template<class Point>
-			using cgal_infer_point_kernel_t = typename cgal_infer_point_kernel<Point>::type;
-		}
-
-		template<typename Point = typename CGAL::Point_2<CGAL::Exact_predicates_exact_constructions_kernel>>
+		template<typename CGALKernel = CGAL::Exact_predicates_exact_constructions_kernel>
 		class PolySimp {
-			using CGALKernel = PolySimpCustomization::cgal_infer_point_kernel_t<Point>;
-			using CGALPoint = Point;
-			using CGALPolygon = CGAL::Polygon_2<CGALKernel, std::vector<Point>>;
+			using CGALPoint = typename CGALKernel::Point_2;
+			using CGALPolygon = CGAL::Polygon_2<CGALKernel, std::vector<CGALPoint>>;
 			
 			using CGALBoundedKernel = CGAL::Bounded_kernel<CGALKernel>;
 			using NefPolyhedron = CGAL::Nef_polyhedron_2<CGALBoundedKernel>;

--- a/include/PolygonSimplification.hpp
+++ b/include/PolygonSimplification.hpp
@@ -33,63 +33,63 @@
 
 namespace com {
 	namespace geopipe {
-		namespace PolySimp {
-			using CGALKernel = CGAL::Exact_predicates_exact_constructions_kernel;
-			using CGALPoint = CGALKernel::Point_2;
-			using CGALPolygon = CGAL::Polygon_2<CGALKernel>;
+		template<typename Kernel = CGAL::Exact_predicates_exact_constructions_kernel, typename Point = typename Kernel::Point_2>
+		class PolySimp {
+			using CGALKernel = Kernel;
+			using CGALPoint = Point;
+			using CGALPolygon = CGAL::Polygon_2<CGALKernel, std::vector<Point>>;
 			
 			using CGALBoundedKernel = CGAL::Bounded_kernel<CGALKernel>;
 			using NefPolyhedron = CGAL::Nef_polyhedron_2<CGALBoundedKernel>;
-			using PolyExplorer = NefPolyhedron::Explorer;
+			using PolyExplorer = typename NefPolyhedron::Explorer;
+
+			// Private methods - previously ::detail within namespace
 			
-			namespace detail {
-				using std::vector;
-				
-				auto identity = [](vector<CGALPoint> &p){ return p; };
-				auto points2Poly = [](vector<CGALPoint> &p){ return CGALPolygon(p.cbegin(), p.cend()); };
-				template<typename T> using BareType = typename std::remove_cv<typename std::remove_reference<T>::type>::type;
-				
-				/**************************************************
-				 * Extracts the finite faces from a Nef polyhedron
-				 * @arg explorer The `CGAL::Nef_polyhedron_2<CGALBoundedKernel>::Explorer
-				 * to traverse.
-				 * @arg faces The output container, must support
-				 * `std::back_inserter`. Typically `std::vector<E>
-				 * for some face-type `E`.
-				 * @arg f A functor from 
-				 * `std::vector<CGAL::Exact_predicates_exact_constructions_kernel::Point_2>` 
-				 * to `E`, where `E` is the element type of `faces`.
-				 **************************************************/
-				template<typename T, typename F = decltype(identity)> void extractFiniteFaces(const PolyExplorer &explorer, T& faces, F f = identity) {
-					using Face = BareType<decltype(*explorer.faces_begin())>;
-					std::transform(++(explorer.faces_begin()), explorer.faces_end(), std::back_inserter(faces), [&f](const Face &face){
-						/*
-						if (std::distance(face.fc_begin(), face.fc_end()) > 0) {
-							std::cerr << ("There shouldn't be a hole in the interior of this face, "
-										  "because it's the result of tracing a single polyline into the plane\n") << std::endl;
-						}
-						*/
-						
-						CGAL::Container_from_circulator<PolyExplorer::Halfedge_around_face_const_circulator> edges(face.halfedge());
-						using Edge = BareType<decltype(*edges.begin())>;
-						vector<CGALPoint> points;
-						// As long as we are using a Bounded_kernel, we don't need to worry that the vertex is actually a ray.
-						std::transform(edges.begin(), edges.end(), std::back_inserter(points), [](const Edge &edge){ return edge.vertex()->point(); });
-						
-						return f(points);
-					});
-				}
-				/// Dump some info on `poly` to `std::cout`.
-				void debugNef(const NefPolyhedron &poly) {
-					vector<CGALPolygon> temp;
-					PolyExplorer explorer = poly.explorer();
-					extractFiniteFaces(poly.explorer(), temp, points2Poly);
-					std::for_each(temp.cbegin(), temp.cend(), [](const CGALPolygon &poly){
-						std::cout << "\t" << poly << " ( is simple? " << poly.is_simple() << " )" << std::endl;
-					});
-				}
+			static constexpr auto identity = [](std::vector<CGALPoint> &p) constexpr { return p; };
+			static constexpr auto points2Poly = [](std::vector<CGALPoint> &p) constexpr { return CGALPolygon(p.cbegin(), p.cend()); };
+			template<typename T> using BareType = typename std::remove_cv<typename std::remove_reference<T>::type>::type;
+			
+			/**************************************************
+			 * Extracts the finite faces from a Nef polyhedron
+			 * @arg explorer The `CGAL::Nef_polyhedron_2<CGALBoundedKernel>::Explorer
+			 * to traverse.
+			 * @arg faces The output container, must support
+			 * `std::back_inserter`. Typically `std::vector<E>
+			 * for some face-type `E`.
+			 * @arg f A functor from 
+			 * `std::vector<CGAL::Exact_predicates_exact_constructions_kernel::Point_2>` 
+			 * to `E`, where `E` is the element type of `faces`.
+			 **************************************************/
+			template<typename T, typename F = decltype(identity)> static void extractFiniteFaces(const PolyExplorer &explorer, T& faces, F f = identity) {
+				using Face = BareType<decltype(*explorer.faces_begin())>;
+				std::transform(++(explorer.faces_begin()), explorer.faces_end(), std::back_inserter(faces), [&f](const Face &face){
+					/*
+					if (std::distance(face.fc_begin(), face.fc_end()) > 0) {
+						std::cerr << ("There shouldn't be a hole in the interior of this face, "
+									  "because it's the result of tracing a single polyline into the plane\n") << std::endl;
+					}
+					*/
+					
+					CGAL::Container_from_circulator<typename PolyExplorer::Halfedge_around_face_const_circulator> edges(face.halfedge());
+					using Edge = BareType<decltype(*edges.begin())>;
+					std::vector<CGALPoint> points;
+					// As long as we are using a Bounded_kernel, we don't need to worry that the vertex is actually a ray.
+					std::transform(edges.begin(), edges.end(), std::back_inserter(points), [](const Edge &edge){ return edge.vertex()->point(); });
+					
+					return f(points);
+				});
 			}
-			
+			/// Dump some info on `poly` to `std::cout`.
+			void debugNef(const NefPolyhedron &poly) {
+				std::vector<CGALPolygon> temp;
+				PolyExplorer explorer = poly.explorer();
+				extractFiniteFaces(poly.explorer(), temp, points2Poly);
+				std::for_each(temp.cbegin(), temp.cend(), [](const CGALPolygon &poly){
+					std::cout << "\t" << poly << " ( is simple? " << poly.is_simple() << " )" << std::endl;
+				});
+			}
+
+		  public:
 			/*******************************************************************************
 			 * Converts an edge soup into a set of simple, orientable, finite-area polygons.
 			 * 
@@ -124,16 +124,16 @@ namespace com {
 			 * 
 			 * </pre>
 			 *******************************************************************************/
-			std::vector<CGALPolygon> simplifyPolygon(const CGALPolygon &inp, bool auto_close = true){
+			static std::vector<CGALPolygon> simplifyPolygon(const CGALPolygon &inp, bool auto_close = true) {
 				using std::pair;
 				using std::vector;
-				using PointIter = vector<CGALPoint>::const_iterator;
+				using PointIter = typename vector<CGALPoint>::const_iterator;
 				using PointIterPair = pair<PointIter, PointIter>;
 				
 				vector<CGALPoint> points(inp.container());
 				vector<CGALPolygon> polys;
 				
-				if(auto_close){
+				if (auto_close) {
 					points.push_back(inp.container().front());
 				}
 				
@@ -145,7 +145,7 @@ namespace com {
 				NefPolyhedron area_pointset = (whole_plane - boundary_pointset).interior();
 				
 				vector<vector<CGALPoint> > components;
-				detail::extractFiniteFaces(area_pointset.explorer(), components);
+				extractFiniteFaces(area_pointset.explorer(), components);
 				
 				vector<PointIterPair> component_polys;
 				std::transform(components.cbegin(), components.cend(), std::back_inserter(component_polys), [](const vector<CGALPoint> &component) {
@@ -156,17 +156,15 @@ namespace com {
 				NefPolyhedron remainder = std::accumulate(component_polys.cbegin(), component_polys.cend(), NefPolyhedron(NefPolyhedron::EMPTY), [](const NefPolyhedron& left, const PointIterPair& right){
 					return left.join(NefPolyhedron(right.first, right.second));
 				});
-				//detail::debugNef(remainder);
+				//debugNef(remainder);
 				
 				NefPolyhedron remainder_clean = remainder.regularization().interior();
-				//detail::debugNef(remainder_clean);
+				//debugNef(remainder_clean);
 				
-				detail::extractFiniteFaces(remainder_clean.explorer(), polys, detail::points2Poly);
+				extractFiniteFaces(remainder_clean.explorer(), polys, points2Poly);
 				
 				return polys;
 			}
-			
-			
 		};
 	};
 };

--- a/main.cpp
+++ b/main.cpp
@@ -5,9 +5,11 @@
 
 #include <PolygonSimplification.hpp>
 
-using namespace com::geopipe::PolySimp;
+using namespace com::geopipe;
 
 int main(int argc, const char* argv[]) {
+	using simp = PolySimp;
+
 	int ret;
 	if((!argc % 2)){
 		std::cout << argv[0] << " x0 y0 [... xn yn]" << std::endl;
@@ -15,16 +17,16 @@ int main(int argc, const char* argv[]) {
 	} else {
 		typedef const char * (*CStrPair)[2];
 		CStrPair arg_pairs = (CStrPair)(argv + 1);
-		std::vector<CGALPoint> problemNodes;
+		std::vector<simp.CGALPoint> problemNodes;
 		
 		std::transform(arg_pairs, arg_pairs + (argc / 2), std::back_inserter(problemNodes),
 					   [](const char *(arg[2])){
 						   return CGALPoint(std::atof(arg[0]), std::atof(arg[1]));
 					   });
 		
-		CGALPolygon test(problemNodes.cbegin(), problemNodes.cend());
+		simp.CGALPolygon test(problemNodes.cbegin(), problemNodes.cend());
 		
-		std::vector<CGALPolygon> fixed = simplifyPolygon(test);
+		std::vector<simp.CGALPolygon> fixed = simp.simplifyPolygon(test);
 		std::cout << "Finished set: " <<  std::endl;
 		std::for_each(fixed.cbegin(), fixed.cend(), [](const CGALPolygon &poly){
 			std::cout << "\t" << poly << " ( is simple? " << poly.is_simple() << " )" << std::endl;


### PR DESCRIPTION
Allows different CGAL kernel and point types to be used than the values previously hard-coded, making this more generally useful. In order to provide templating, converts `PolySimp` from a namespace to a class, but tries to retain the intended structure as much as possible.